### PR TITLE
Add async agent manager utility

### DIFF
--- a/plexe/internal/common/utils/__init__.py
+++ b/plexe/internal/common/utils/__init__.py
@@ -1,3 +1,5 @@
-"""
-Common utility functions for the plexe library.
-"""
+"""Common utility functions for the plexe library."""
+
+from .async_agents import run_agents_concurrently
+
+__all__ = ["run_agents_concurrently"]

--- a/plexe/internal/common/utils/async_agents.py
+++ b/plexe/internal/common/utils/async_agents.py
@@ -1,0 +1,21 @@
+"""Utility helpers for running agent tasks concurrently."""
+
+from typing import Awaitable, Callable, Iterable, List, Any
+import asyncio
+
+
+def run_agents_concurrently(agents: Iterable[Callable[[], Awaitable[Any]]]) -> List[Any]:
+    """Run multiple asynchronous agent tasks concurrently.
+
+    Args:
+        agents: Iterable of callables returning awaitable tasks.
+
+    Returns:
+        List of agent results in the order they were supplied.
+    """
+
+    async def _run() -> List[Any]:
+        tasks = [asyncio.create_task(agent()) for agent in agents]
+        return await asyncio.gather(*tasks, return_exceptions=True)
+
+    return asyncio.run(_run())

--- a/tests/unit/internal/common/utils/test_async_agents.py
+++ b/tests/unit/internal/common/utils/test_async_agents.py
@@ -1,0 +1,19 @@
+"""Tests for asynchronous agent utilities."""
+
+import time
+import asyncio
+
+from plexe.internal.common.utils import run_agents_concurrently
+
+
+async def _slow(value: int) -> int:
+    await asyncio.sleep(0.1)
+    return value
+
+
+def test_run_agents_concurrently_executes_tasks():
+    start = time.perf_counter()
+    results = run_agents_concurrently([lambda: _slow(1), lambda: _slow(2)])
+    elapsed = time.perf_counter() - start
+    assert results == [1, 2]
+    assert elapsed < 0.2


### PR DESCRIPTION
## Summary
- implement `run_agents_concurrently` utility for running async tasks in parallel
- expose utility from `plexe.internal.common.utils`
- test concurrent execution behavior

## Testing
- `pre-commit run --files plexe/internal/common/utils/async_agents.py plexe/internal/common/utils/__init__.py tests/unit/internal/common/utils/test_async_agents.py`
- `PYTHONPATH=$PWD pytest tests/unit/internal/common/utils/test_async_agents.py -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'mlebench')*

------
https://chatgpt.com/codex/tasks/task_e_687d2866a9ec8323be280fc2bce7755d